### PR TITLE
Process fragments without @Arg

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -99,6 +99,7 @@ public class ArgProcessor extends AbstractProcessor {
   public Set<String> getSupportedAnnotationTypes() {
     Set<String> supportTypes = new LinkedHashSet<String>();
     supportTypes.add(Arg.class.getCanonicalName());
+    supportTypes.add(FragmentWithArgs.class.getCanonicalName());
     supportTypes.add(FragmentArgsInherited.class.getCanonicalName());
     return supportTypes;
   }


### PR DESCRIPTION
Fragments with `@FragmentWithArgs` but with no `@Arg` are not processed by this library.
